### PR TITLE
make maximum amount configurable

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,6 +9,7 @@ class Switch(BaseModel):
     pin: int = 0
     comment: bool = False
     variable: bool = False
+    max_variable: int = 100
     label: str | None = None
 
 

--- a/static/index.vue
+++ b/static/index.vue
@@ -306,6 +306,14 @@
                     >Variable time (Amount * Duration)</q-tooltip
                   ></q-checkbox
                 >
+                <q-input
+                  v-if="_switch.variable"
+                  filled
+                  dense
+                  v-model.number="_switch.max_variable"
+                  type="number"
+                  label="Max multiplier"
+                ></q-input>
                 <q-checkbox
                   v-model="_switch.comment"
                   color="primary"

--- a/views_lnurl.py
+++ b/views_lnurl.py
@@ -48,8 +48,8 @@ async def lnurl_params(
         )
         * 1000
     )
-    # let the max be 100x the min if variable pricing is enabled
-    max_sendable = price_msat * 100 if _switch.variable else price_msat
+    # let the max be max_variable times the min if variable pricing is enabled
+    max_sendable = price_msat * _switch.max_variable if _switch.variable else price_msat
     url = request.url_for("bitcoinswitch.lnurl_cb", switch_id=bitcoinswitch_id, pin=pin)
     try:
         callback_url = parse_obj_as(CallbackUrl, str(url))


### PR DESCRIPTION
This (vibed) pull request attempts to address issue #54 . It makes the maximum amount configurable, considering that in many circumstances a Bitcoin Switch operator may still want to limit the maximum payment amount.